### PR TITLE
dependency update

### DIFF
--- a/src/pipelines/real-estate/pyproject.toml
+++ b/src/pipelines/real-estate/pyproject.toml
@@ -1,7 +1,26 @@
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "realestate-pipeline"
+version = "0.1.0"
+dependencies = [
+  "dagster",
+  "dagster-deltalake",
+  "dagster-deltalake-pandas",
+  "deltalake==0.17.0",
+  "beautifulsoup4",
+  "pandas",
+  "requests"
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest",
+  "black",
+  "ruff"
+]
 
 [tool.dagster]
 module_name = "realestate"


### PR DESCRIPTION
This PR declares project dependencies in pyproject.toml and pins deltalake==0.17.0 to fix a runtime incompatibility with dagster-deltalake (_filters_to_expression import error).

This makes local setup reproducible and prevents Dagster import failures on fresh environments (especially Python 3.12).